### PR TITLE
update Composer before running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ php:
   - 5.5
   - 5.6
   - 7
+  
+before_install:
+  - composer self-update
 
 install:
   - composer install


### PR DESCRIPTION
Looks like the Composer version provided by Travis CI by default (which is more than a year old) was causing the build failures in #6.
